### PR TITLE
Correction de l'échappement automatique du HTML par Jinja

### DIFF
--- a/atlas/templates/speciesSheet/blocInfos.html
+++ b/atlas/templates/speciesSheet/blocInfos.html
@@ -38,14 +38,14 @@
             {% if taxonDescription.milieu == None %}
             {{ _('not.resigned.for.the.moment') }}
             {% else %}
-            {{ taxonDescription.milieu }}
+            {{ taxonDescription.milieu | safe }}
             {% endif %}
         </div>
         <div id="chorologie" class="tab-pane fade">
             {% if taxonDescription.chorologie == None %}
             {{ _('not.resigned.for.the.moment') }}
             {% else %}
-            {{ taxonDescription.chorologie }}
+            {{ taxonDescription.chorologie | safe }}
             {% endif %}
         </div>
         <div id="synonymes" class="tab-pane fade">


### PR DESCRIPTION
Le paramètre Safe n'était pas rensigné pour les onglets Milieux et Chorologie. (ce qui empechait le bon affichage des balises html)